### PR TITLE
Fix assignment recovery with multiple tabs

### DIFF
--- a/src/DefaultHomepageActions.js
+++ b/src/DefaultHomepageActions.js
@@ -182,10 +182,12 @@ function startsWith(str, maybePrefix) {
 
 class UserActions extends React.Component {
     state = {
-             showActionsMobile: false,
-             teacherRecoveredSorting: "DATE",
-             studentRecoveredSorting: "DATE"
-         };
+        showActionsMobile: false,
+        teacherRecoveredSorting: "DATE",
+        studentRecoveredSorting: "DATE",
+        recoveredStudentDocs: getStudentRecoveredDocs(),
+        recoveredTeacherDocs: getTeacherRecoveredDocs(),
+    };
 
     componentDidMount() {
 
@@ -637,6 +639,16 @@ class UserActions extends React.Component {
             // turn on confirmation dialog upon navigation away
             window.onbeforeunload = checkAllSaved;
             window.location.hash = '';
+
+            function retrieveFromLocalStorage(fullName) {
+                const item = window.localStorage.getItem(fullName);
+                if (item === null) {
+                    throw new Error("Error reading recovery document");
+                }
+
+                return item;
+            }
+
             function base64ToArrayBuffer(base64) {
                 var binary_string = window.atob(base64);
                 var len = binary_string.length;
@@ -648,23 +660,24 @@ class UserActions extends React.Component {
             }
 
             var recovered;
-            const loadLegacyFormat = function() {
+            function loadLegacyFormat() {
                 try {
                     document.body.scrollTop = document.documentElement.scrollTop = 0;
-                    recovered = JSON.parse(window.localStorage.getItem(autoSaveFullName));
+                    recovered = JSON.parse(retrieveFromLocalStorage(autoSaveFullName));
                     window.store.dispatch({"type" : "SET_GLOBAL_STATE", "newState" : recovered });
-                } catch (e2) {
-                    alert("Error reading recovery document");
-                    return;
+                } catch (e) {
+                    alert(e);
+                    throw e;
                 }
             }
             document.body.scrollTop = document.documentElement.scrollTop = 0;
             if (appMode === EDIT_ASSIGNMENT) {
                 window.ga('send', 'event', 'Actions', 'open', 'Recovered Assignment');
                 try {
-                    recovered = openAssignment(base64ToArrayBuffer(
-                        window.localStorage.getItem(autoSaveFullName)),
-                        filename);
+                    recovered = openAssignment(
+                        base64ToArrayBuffer(retrieveFromLocalStorage(autoSaveFullName)),
+                        filename,
+                    );
                 } catch (e) {
                     loadLegacyFormat();
                     return;
@@ -693,7 +706,7 @@ class UserActions extends React.Component {
 
                 try {
                     loadStudentDocsFromZip(
-                        base64ToArrayBuffer(window.localStorage.getItem(autoSaveFullName)),
+                        base64ToArrayBuffer(retrieveFromLocalStorage(autoSaveFullName)),
                         filename, function() {/* success */}, function() {
                             // loading failed, try the old format
                             loadLegacyFormat();
@@ -759,8 +772,8 @@ class UserActions extends React.Component {
         // tree and then kept in sync with what is actually stored through
         // actions use subscribers
         //https://stackoverflow.com/questions/35305661/where-to-write-to-localstorage-in-a-redux-app
-        var recoveredStudentDocs = getStudentRecoveredDocs();
-        var recoveredTeacherDocs = getTeacherRecoveredDocs();
+        var recoveredStudentDocs = this.state.recoveredStudentDocs;
+        var recoveredTeacherDocs = this.state.recoveredTeacherDocs;
 
         // sort by date, TODO - also allow switch to sort by name
         if (this.state.studentRecoveredSorting === "DATE") {
@@ -967,8 +980,15 @@ class UserActions extends React.Component {
                                                         <br />
                                                         <Button text="Open"
                                                                 onClick={function() {
-                                                                    recoverAutoSaveCallback(autoSaveFullName, filename, EDIT_ASSIGNMENT)}
-                                                                } />
+                                                                    try {
+                                                                      recoverAutoSaveCallback(autoSaveFullName, filename, EDIT_ASSIGNMENT);
+                                                                    } catch (e) {
+                                                                      this.setState({
+                                                                        ...this.state,
+                                                                        recoveredStudentDocs: getStudentRecoveredDocs(),
+                                                                      });
+                                                                    }
+                                                                }.bind(this)} />
                                                         <Button text="Delete"
                                                                 onClick={function() {
                                                                     deleteAutoSaveCallback(autoSaveFullName)}
@@ -977,7 +997,7 @@ class UserActions extends React.Component {
                                                         <br />
                                                         </div>
                                                 );
-                                            }) }
+                                            }.bind(this)) }
                                     </span>) : null }
                         { (recoveredStudentDocs.length > 0) ?
                             (<p>Recovered assignments stored temporarily in your
@@ -1073,8 +1093,15 @@ class UserActions extends React.Component {
                                                         <br />
                                                         <Button text="Open"
                                                                 onClick={function() {
-                                                                    recoverAutoSaveCallback(autoSaveFullName, filename, GRADE_ASSIGNMENTS)}
-                                                                } />
+                                                                    try {
+                                                                        recoverAutoSaveCallback(autoSaveFullName, filename, GRADE_ASSIGNMENTS);
+                                                                    } catch (e) {
+                                                                        this.setState({
+                                                                          ...this.state,
+                                                                          recoveredTeacherDocs: getTeacherRecoveredDocs(),
+                                                                        });
+                                                                    }
+                                                                }.bind(this)} />
                                                         <Button text="Delete"
                                                                 onClick={function() {
                                                                     deleteAutoSaveCallback(autoSaveFullName)}
@@ -1083,7 +1110,7 @@ class UserActions extends React.Component {
                                                         <br />
                                                         </div>
                                                 );
-                                            }) }
+                                            }.bind(this)) }
                                     </span>) : null }
                     { (recoveredTeacherDocs.length > 0) ?
                             (<p>Recovered grading sessions stored temporarily in


### PR DESCRIPTION
Error stemmed from `localStorage` item being removed in one tab, but the other tab still attempted to load it. Now, there is consistent error checking for a missing item when loading from `localStorage`.

Recovery items were added to the component's state (as they are used in the rendering process); on failure, recovery items are retrieved from `localStorage` again so they are up-to-date and user can try loading most recent assignment again.